### PR TITLE
autoupdater fixes

### DIFF
--- a/examples/autoupdater.py
+++ b/examples/autoupdater.py
@@ -56,4 +56,4 @@ def restart():
 
 
 def initialize():
-    threading.Thread(target=_worker).start()
+    threading.Thread(target=_worker, daemon=True).start()

--- a/examples/autoupdater.py
+++ b/examples/autoupdater.py
@@ -2,7 +2,6 @@
 # to manually restart it.
 
 import atexit
-import inspect
 import os
 import subprocess
 import sys
@@ -53,15 +52,8 @@ def restart():
         # this is our kind-of CPython hack.
         atexit._run_exitfuncs()
 
-    os.execlp(sys.executable, sys.executable, filepath)
+    os.execvp(sys.executable, [sys.executable] + sys.argv)
 
 
 def initialize():
-    # TODO: Not use globals.
-    global filepath
-
-    # Initialize the auto-updater. Must be called in the main script.
-    parent_globals = inspect.currentframe().f_back.f_globals
-    assert parent_globals["__name__"] == "__main__"
-    filepath = parent_globals["__file__"]
     threading.Thread(target=_worker).start()


### PR DESCRIPTION
- pass arguments when re-execing
- use `sys.argv` instead of `global filepath`
- don't let daemon thread block process exit
- ~add asks 1.2.1 as dependency~