### PR TITLE
Add SASL functionality.

### DIFF
--- a/examples/pyhtonbot.py
+++ b/examples/pyhtonbot.py
@@ -482,7 +482,7 @@ async def main():
         nickname = os.environ["IRC_USERNAME"]
         password = os.environ.get("IRC_PASSWORD")
 
-        await bot.connect(nickname, "chat.freenode.net", password=password)
+        await bot.connect(nickname, "chat.freenode.net", sasl_password=password)
         await bot.join_channel("#8banana-bottest")
     else:
         await bot.connect("pyhtonbot", "chat.freenode.net")

--- a/examples/pyhtonbot.py
+++ b/examples/pyhtonbot.py
@@ -6,6 +6,7 @@ We actually use this one on the #8Banana IRC channel :)
 
 import collections
 import datetime
+import os
 import random
 import re
 import sys
@@ -476,16 +477,14 @@ async def main():
     asks.init("curio")
     autoupdater.initialize()
 
+    password = os.environ.get("IRC_PASSWORD")
+
     if len(sys.argv) > 1 and sys.argv[1] == "debug":
-        import os
-
-        nickname = os.environ["IRC_USERNAME"]
-        password = os.environ.get("IRC_PASSWORD")
-
+        nickname = os.environ["IRC_NICKNAME"]
         await bot.connect(nickname, "chat.freenode.net", sasl_password=password)
         await bot.join_channel("#8banana-bottest")
     else:
-        await bot.connect("pyhtonbot", "chat.freenode.net")
+        await bot.connect("pyhtonbot", "chat.freenode.net", sasl_password=password)
         await bot.join_channel("#8banana")
         await bot.join_channel("##learnpython")
         await bot.join_channel("#lpmc")

--- a/examples/pyhtonbot.py
+++ b/examples/pyhtonbot.py
@@ -477,7 +477,12 @@ async def main():
     autoupdater.initialize()
 
     if len(sys.argv) > 1 and sys.argv[1] == "debug":
-        await bot.connect("pyhtonbot2", "chat.freenode.net")
+        import os
+
+        nickname = os.environ["IRC_USERNAME"]
+        password = os.environ.get("IRC_PASSWORD")
+
+        await bot.connect(nickname, "chat.freenode.net", password=password)
         await bot.join_channel("#8banana-bottest")
     else:
         await bot.connect("pyhtonbot", "chat.freenode.net")

--- a/nettirely.py
+++ b/nettirely.py
@@ -146,9 +146,9 @@ class IrcBot:
 
         if autoreply_to_ping and line.startswith("PING"):
             await self._send(line.replace("PING", "PONG", 1))
-            return (await self._recv_line(autoreply_to_ping=True, skip_empty_lines=skip_empty_lines))
+            return await self._recv_line(autoreply_to_ping=True, skip_empty_lines=skip_empty_lines)
         elif skip_empty_lines and (not line):
-            return (await self._recv_line(autoreply_to_ping=autoreply_to_ping, skip_empty_lines=True))
+            return await self._recv_line(autoreply_to_ping=autoreply_to_ping, skip_empty_lines=True)
         else:
             return line
 

--- a/nettirely.py
+++ b/nettirely.py
@@ -134,13 +134,9 @@ class IrcBot:
 
         if autoreply_to_ping and line.startswith("PING"):
             await self._send(line.replace("PING", "PONG", 1))
-
-            # Let's fetch another line from the server. I wrote this using
-            # recursion because I didn't feel like re-writing this function to
-            # be iterative.
-            return self._recv_line(autoreply_to_ping=True, skip_empty_lines=skip_empty_lines)
+            return (await self._recv_line(autoreply_to_ping=True, skip_empty_lines=skip_empty_lines))
         elif skip_empty_lines and (not line):
-            return self._recv_line(autoreply_to_ping=autoreply_to_ping, skip_empty_lines=True)
+            return (await self._recv_line(autoreply_to_ping=autoreply_to_ping, skip_empty_lines=True))
         else:
             return line
 


### PR DESCRIPTION
This PR adds SASL functionality to the IrcBot class. It supports the SASL `PLAIN` mechanism, and none other. There seems to be little support for any other mechanism. Of course, this is very insecure until we add SSL/TLS support, which shouldn't be too difficult to add but this is more important due to the recent influx of spammers on Freenode.

I've also added a few lines to `pyhtonbot` which automatically utilize a password found in the `IRC_PASSWORD `environment variable.

Make sure to merge this if and only if theelous3 is available to register with NickServ the bot and set up auto-op for it. 